### PR TITLE
Show Nepeta's head being thrown in kernelsprite

### DIFF
--- a/Readable Timelines/nepetasprite.txt
+++ b/Readable Timelines/nepetasprite.txt
@@ -4,7 +4,7 @@ Image: nepetasprite.png
 Group: Alpha Kids' Sprites
 
 Be created by Japrosesprite^2
-9720-9722
+9718-9722
 
 Witness creation of GCatavrosprite
 9731-9739


### PR DESCRIPTION
The path from the end of nepeta.txt to the beginning of nepetasprite is a bit confusing.  I think it reads better if we see Nepeta's head being thrown into the kernel sprite.

On the other hand, it may feel confusing switching perspective from Nepeta's ghost to Nepeta's body.

What do you think?